### PR TITLE
Chain letter problems

### DIFF
--- a/examples/bpti-ncmc/bpti-ncmc.py
+++ b/examples/bpti-ncmc/bpti-ncmc.py
@@ -10,9 +10,9 @@ to see equilibrated behaviour
 Marley Samways
 """
 
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 from sys import stdout
 
 from openmmtools.integrators import BAOABIntegrator

--- a/examples/bpti/equil/equil-npt.py
+++ b/examples/bpti/equil/equil-npt.py
@@ -8,9 +8,9 @@ Marley Samways
 Ollie Melling
 """
 
-from simtk.openmm import *
-from simtk.openmm.app import *
-from simtk.unit import *
+from openmm import *
+from openmm.app import *
+from openmm.unit import *
 from openmmtools.integrators import BAOABIntegrator
 from sys import stdout
 import numpy as np

--- a/examples/bpti/equil/equil-uvt1.py
+++ b/examples/bpti/equil/equil-uvt1.py
@@ -8,9 +8,9 @@ Marley Samways
 Ollie Melling
 """
 
-from simtk.openmm import *
-from simtk.openmm.app import *
-from simtk.unit import *
+from openmm import *
+from openmm.app import *
+from openmm.unit import *
 from openmmtools.integrators import BAOABIntegrator
 from sys import stdout
 import numpy as np

--- a/examples/bpti/equil/equil-uvt2.py
+++ b/examples/bpti/equil/equil-uvt2.py
@@ -8,9 +8,9 @@ Marley Samways
 Ollie Melling
 """
 
-from simtk.openmm import *
-from simtk.openmm.app import *
-from simtk.unit import *
+from openmm import *
+from openmm.app import *
+from openmm.unit import *
 from openmmtools.integrators import BAOABIntegrator
 from sys import stdout
 import numpy as np

--- a/examples/bpti/prod/bpti-restart.py
+++ b/examples/bpti/prod/bpti-restart.py
@@ -11,9 +11,9 @@ Marley Samways
 Ollie Melling
 """
 
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 from sys import stdout
 
 from openmmtools.integrators import BAOABIntegrator

--- a/examples/bpti/prod/bpti.py
+++ b/examples/bpti/prod/bpti.py
@@ -10,9 +10,9 @@ Marley Samways
 Ollie Melling
 """
 
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 from sys import stdout
 
 from openmmtools.integrators import BAOABIntegrator

--- a/examples/scytalone/scytalone.py
+++ b/examples/scytalone/scytalone.py
@@ -9,9 +9,9 @@ to see equilibrated behaviour
 Marley Samways
 """
 
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 from sys import stdout
 
 from openmmtools.integrators import BAOABIntegrator

--- a/examples/water/water.py
+++ b/examples/water/water.py
@@ -9,9 +9,9 @@ to see equilibrated behaviour
 Marley Samways
 """
 
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 from sys import stdout
 import numpy as np
 

--- a/grand/potential.py
+++ b/grand/potential.py
@@ -155,16 +155,16 @@ def calc_mu_ex(system, topology, positions, box_vectors, temperature, n_lambdas,
     # Calculate equilibration & number of uncorrelated samples
     N_k = np.zeros(n_lambdas, np.int32)
     for i in range(n_lambdas):
-        n_equil, g, neff_max = pymbar.timeseries.detectEquilibration(U[i, i, :])
-        indices = pymbar.timeseries.subsampleCorrelatedData(U[i, i, :], g=g)
+        n_equil, g, neff_max = pymbar.timeseries.detect_equilibration(U[i, i, :])
+        indices = pymbar.timeseries.subsample_correlated_data(U[i, i, :], g=g)
         N_k[i] = len(indices)
         U[i, :, 0:N_k[i]] = U[i, :, indices].T
 
     # Calculate free energy differences
     mbar = pymbar.MBAR(U, N_k)
-    results = mbar.getFreeEnergyDifferences()
-    deltaG_ij = results[0]
-    ddeltaG_ij = results[1]
+    results = mbar.compute_free_energy_differences()
+    deltaG_ij = results['Delta_f']
+    ddeltaG_ij = results['dDelta_f']
 
     # Extract overall free energy change
     dG = -deltaG_ij[0, -1]

--- a/grand/potential.py
+++ b/grand/potential.py
@@ -155,16 +155,16 @@ def calc_mu_ex(system, topology, positions, box_vectors, temperature, n_lambdas,
     # Calculate equilibration & number of uncorrelated samples
     N_k = np.zeros(n_lambdas, np.int32)
     for i in range(n_lambdas):
-        n_equil, g, neff_max = pymbar.timeseries.detect_equilibration(U[i, i, :])
-        indices = pymbar.timeseries.subsample_correlated_data(U[i, i, :], g=g)
+        n_equil, g, neff_max = pymbar.timeseries.detectEquilibration(U[i, i, :])
+        indices = pymbar.timeseries.subsampleCorrelatedData(U[i, i, :], g=g)
         N_k[i] = len(indices)
         U[i, :, 0:N_k[i]] = U[i, :, indices].T
 
     # Calculate free energy differences
     mbar = pymbar.MBAR(U, N_k)
-    results = mbar.compute_free_energy_differences()
-    deltaG_ij = results['Delta_f']
-    ddeltaG_ij = results['dDelta_f']
+    results = mbar.getFreeEnergyDifferences()
+    deltaG_ij = results[0]
+    ddeltaG_ij = results[1]
 
     # Extract overall free energy change
     dG = -deltaG_ij[0, -1]

--- a/grand/potential.py
+++ b/grand/potential.py
@@ -11,9 +11,9 @@ Marley Samways
 import numpy as np
 import pymbar
 import openmmtools
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 
 import grand
 
@@ -57,15 +57,15 @@ def calc_mu_ex(system, topology, positions, box_vectors, temperature, n_lambdas,
 
     Parameters
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
         System of interest
-    topology : simtk.openmm.app.Topology
+    topology : openmm.app.Topology
         Topology of the system
-    positions : simtk.unit.Quantity
+    positions : openmm.unit.Quantity
         Initial positions for the simulation
-    box_vectors : simtk.unit.Quantity
+    box_vectors : openmm.unit.Quantity
         Periodic box vectors for the system
-    temperature : simtk.unit.Quantity
+    temperature : openmm.unit.Quantity
         Temperature of the simulation
     n_lambdas : int
         Number of lambda values
@@ -78,7 +78,7 @@ def calc_mu_ex(system, topology, positions, box_vectors, temperature, n_lambdas,
 
     Returns
     -------
-    dG : simtk.unit.Quantity
+    dG : openmm.unit.Quantity
         Calculated free energy value
     """
     # Use the BAOAB integrator to sample the equilibrium distribution
@@ -191,15 +191,15 @@ def calc_std_volume(system, topology, positions, box_vectors, temperature, n_sam
 
     Parameters
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
         System of interest
-    topology : simtk.openmm.app.Topology
+    topology : openmm.app.Topology
         Topology of the system
-    positions : simtk.unit.Quantity
+    positions : openmm.unit.Quantity
         Initial positions for the simulation
-    box_vectors : simtk.unit.Quantity
+    box_vectors : openmm.unit.Quantity
         Periodic box vectors for the system
-    temperature : simtk.unit.Quantity
+    temperature : openmm.unit.Quantity
         Temperature of the simulation
     n_samples : int
         Number of volume samples to collect
@@ -208,7 +208,7 @@ def calc_std_volume(system, topology, positions, box_vectors, temperature, n_sam
 
     Returns
     -------
-    std_volume : simtk.unit.Quantity
+    std_volume : openmm.unit.Quantity
         Calculated free energy value
     """
     # Use the BAOAB integrator to sample the equilibrium distribution

--- a/grand/samplers.py
+++ b/grand/samplers.py
@@ -1073,6 +1073,14 @@ class StandardGCMCSphereSampler(GCMCSphereSampler):
             Number of moves to execute
         report : If true, call the report function after the move - this parameter was added by Cresset as an
             optimisation to ensure that a move followed by a report does not have to get the state twice.
+
+        Returns
+        -------
+        state : openmm.State
+            State object from OpenMM for the current simulation - this return type was added by Cresset as an
+            optimisation so that dcd reporting external to grand can use the state without another expensive
+            call to getState. The dcd reporting from grand's report function uses mdtraj, which does not allow
+            other processes to read the file while it's open for writing on Windows.
         """
         # Read in positions
         self.context = simulation.context
@@ -1102,7 +1110,7 @@ class StandardGCMCSphereSampler(GCMCSphereSampler):
             self.Ns.append(self.N)
         if report:
             self.report(simulation, state)
-        return None
+        return state
 
     def insertionMove(self):
         """
@@ -1292,6 +1300,14 @@ class NonequilibriumGCMCSphereSampler(GCMCSphereSampler):
         report : If true, call the report function after the move - this parameter was added by Cresset as an
             optimisation to ensure that a move followed by a report does not have to get the state twice or update the
             GCMC sphere twice when using NonequilibriumGCMCSphereSampler.
+
+        Returns
+        -------
+        state : openmm.State
+            State object from OpenMM for the current simulation - this return type was added by Cresset as an
+            optimisation so that dcd reporting external to grand can use the state without another expensive
+            call to getState. The dcd reporting from grand's report function uses mdtraj, which does not allow
+            other processes to read the file while it's open for writing on Windows.
         """
         # Read in positions
         self.context = simulation.context
@@ -1321,7 +1337,7 @@ class NonequilibriumGCMCSphereSampler(GCMCSphereSampler):
         self.compound_integrator.setCurrentIntegrator(0)
         if report:
             self.report(simulation, state, updateSphere=False) # updateGCMCSphere has already been called in insertionMove and deletionMove
-        return None
+        return state
 
     def insertionMove(self):
         """
@@ -1756,6 +1772,14 @@ class StandardGCMCSystemSampler(GCMCSystemSampler):
             Number of moves to execute
         report : If true, call the report function after the move - this parameter was added by Cresset as an
             optimisation to ensure that a move followed by a report does not have to get the state twice.
+
+        Returns
+        -------
+        state : openmm.State
+            State object from OpenMM for the current simulation - this return type was added by Cresset as an
+            optimisation so that dcd reporting external to grand can use the state without another expensive
+            call to getState. The dcd reporting from grand's report function uses mdtraj, which does not allow
+            other processes to read the file while it's open for writing on Windows.
         """
         # Read in positions
         self.context = simulation.context
@@ -1776,7 +1800,7 @@ class StandardGCMCSystemSampler(GCMCSystemSampler):
             self.Ns.append(self.N)
         if report:
             self.report(simulation, state)
-        return None
+        return state
 
     def insertionMove(self):
         """
@@ -1956,6 +1980,14 @@ class NonequilibriumGCMCSystemSampler(GCMCSystemSampler):
             Number of moves to execute
         report : If true, call the report function after the move - this parameter was added by Cresset as an
             optimisation to ensure that a move followed by a report does not have to get the state twice.
+
+        Returns
+        -------
+        state : openmm.State
+            State object from OpenMM for the current simulation - this return type was added by Cresset as an
+            optimisation so that dcd reporting external to grand can use the state without another expensive
+            call to getState. The dcd reporting from grand's report function uses mdtraj, which does not allow
+            other processes to read the file while it's open for writing on Windows.
         """
         # Read in positions
         self.context = simulation.context
@@ -1982,7 +2014,7 @@ class NonequilibriumGCMCSystemSampler(GCMCSystemSampler):
         self.compound_integrator.setCurrentIntegrator(0)
         if report:
             self.report(simulation, state)
-        return None
+        return state
 
     def insertionMove(self):
         """

--- a/grand/samplers.py
+++ b/grand/samplers.py
@@ -17,8 +17,8 @@ import logging
 import parmed
 import math
 from copy import deepcopy
-from simtk import unit
-from simtk import openmm
+from openmm import unit
+import openmm
 from openmmtools.integrators import NonequilibriumLangevinIntegrator
 
 from grand.utils import random_rotation_matrix
@@ -38,11 +38,11 @@ class BaseGrandCanonicalMonteCarloSampler(object):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             System object to be used for the simulation
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system to be simulated
-        temperature : simtk.unit.Quantity
+        temperature : openmm.unit.Quantity
             Temperature of the simulation, must be in appropriate units
         ghostFile : str
             Name of a file to write out the residue IDs of ghost water molecules. This is
@@ -347,7 +347,7 @@ class BaseGrandCanonicalMonteCarloSampler(object):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         ghostResids : list
             List of residue IDs corresponding to the ghost waters added
@@ -357,7 +357,7 @@ class BaseGrandCanonicalMonteCarloSampler(object):
 
         Returns
         -------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Updated context, with ghost waters switched off
         """
         # Get a list of all ghost residue IDs supplied from list and file
@@ -430,7 +430,7 @@ class BaseGrandCanonicalMonteCarloSampler(object):
 
         Parameters
         ----------
-        simulation : simtk.openmm.app.Simulation
+        simulation : openmm.app.Simulation
             Simulation object being used
         """
         # Get state
@@ -504,7 +504,7 @@ class BaseGrandCanonicalMonteCarloSampler(object):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         n : int
             Number of moves to execute
@@ -532,21 +532,21 @@ class GCMCSphereSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             System object to be used for the simulation
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system to be simulated
-        temperature : simtk.unit.Quantity
+        temperature : openmm.unit.Quantity
             Temperature of the simulation, must be in appropriate units
         adams : float
             Adams B value for the simulation (dimensionless). Default is None,
             if None, the B value is calculated from the box volume and chemical
             potential
-        excessChemicalPotential : simtk.unit.Quantity
+        excessChemicalPotential : openmm.unit.Quantity
             Excess chemical potential of the system that the simulation should be in equilibrium with, default is
             -6.09 kcal/mol. This should be the hydration free energy of water, and may need to be changed for specific
             simulation parameters.
-        standardVolume : simtk.unit.Quantity
+        standardVolume : openmm.unit.Quantity
             Standard volume of water - corresponds to the volume per water molecule in bulk. The default value is 30.345 A^3
         adamsShift : float
             Shift the B value from Bequil, if B isn't explicitly set. Default is 0.0
@@ -558,9 +558,9 @@ class GCMCSphereSampler(BaseGrandCanonicalMonteCarloSampler):
             List containing dictionaries describing the atoms to use as the centre of the GCMC region
             Must contain 'name' and 'resname' as keys, and optionally 'resid' (recommended) and 'chain'
             e.g. [{'name': 'C1', 'resname': 'LIG', 'resid': '123'}]
-        sphereRadius : simtk.unit.Quantity
+        sphereRadius : openmm.unit.Quantity
             Radius of the spherical GCMC region
-        sphereCentre : simtk.unit.Quantity
+        sphereCentre : openmm.unit.Quantity
             Coordinates around which the GCMC sphere is based
         log : str
             Log file to write out
@@ -713,7 +713,7 @@ class GCMCSphereSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         ghostResids : list
             List of residue IDs corresponding to the ghost waters added
@@ -787,13 +787,13 @@ class GCMCSphereSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the system. Only needs to be supplied if the context
             has changed since the last update
 
         Returns
         -------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Updated context after deleting the relevant waters
         """
         #  Read in positions of the context and update GCMC box
@@ -830,7 +830,7 @@ class GCMCSphereSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Parameters
         ----------
-        state : simtk.openmm.State
+        state : openmm.State
             Current State
         """
         # Make sure the positions are definitely updated
@@ -889,7 +889,7 @@ class GCMCSphereSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Returns
         -------
-        new_positions : simtk.unit.Quantity
+        new_positions : openmm.unit.Quantity
             Positions following the 'insertion' of the ghost water
         insert_water : int
             Residue ID of the water to insert
@@ -971,7 +971,7 @@ class GCMCSphereSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Parameters
         ----------
-        simulation : simtk.openmm.app.Simulation
+        simulation : openmm.app.Simulation
             Simulation object being used
         """
         # Get state
@@ -1022,21 +1022,21 @@ class StandardGCMCSphereSampler(GCMCSphereSampler):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             System object to be used for the simulation
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system to be simulated
-        temperature : simtk.unit.Quantity
+        temperature : openmm.unit.Quantity
             Temperature of the simulation, must be in appropriate units
         adams : float
             Adams B value for the simulation (dimensionless). Default is None,
             if None, the B value is calculated from the box volume and chemical
             potential
-        excessChemicalPotential : simtk.unit.Quantity
+        excessChemicalPotential : openmm.unit.Quantity
             Excess chemical potential of the system that the simulation should be in equilibrium with, default is
             -6.09 kcal/mol. This should be the hydration free energy of water, and may need to be changed for specific
             simulation parameters.
-        standardVolume : simtk.unit.Quantity
+        standardVolume : openmm.unit.Quantity
             Standard volume of water - corresponds to the volume per water molecule in bulk. The default value is 30.345 A^3
         adamsShift : float
             Shift the B value from Bequil, if B isn't explicitly set. Default is 0.0
@@ -1048,9 +1048,9 @@ class StandardGCMCSphereSampler(GCMCSphereSampler):
             List containing dictionaries describing the atoms to use as the centre of the GCMC region
             Must contain 'name' and 'resname' as keys, and optionally 'resid' (recommended) and 'chain'
             e.g. [{'name': 'C1', 'resname': 'LIG', 'resid': '123'}]
-        sphereRadius : simtk.unit.Quantity
+        sphereRadius : openmm.unit.Quantity
             Radius of the spherical GCMC region
-        sphereCentre : simtk.unit.Quantity
+        sphereCentre : openmm.unit.Quantity
             Coordinates around which the GCMC sphere is based
         log : str
             Name of the log file to write out
@@ -1078,7 +1078,7 @@ class StandardGCMCSphereSampler(GCMCSphereSampler):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         n : int
             Number of moves to execute
@@ -1193,24 +1193,24 @@ class NonequilibriumGCMCSphereSampler(GCMCSphereSampler):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             System object to be used for the simulation
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system to be simulated
-        temperature : simtk.unit.Quantity
+        temperature : openmm.unit.Quantity
             Temperature of the simulation, must be in appropriate units
-        integrator : simtk.openmm.CustomIntegrator
+        integrator : openmm.CustomIntegrator
             Integrator to use to propagate the dynamics of the system. Currently want to make sure that this
             is the customised Langevin integrator found in openmmtools which uses BAOAB (VRORV) splitting.
         adams : float
             Adams B value for the simulation (dimensionless). Default is None,
             if None, the B value is calculated from the box volume and chemical
             potential
-        excessChemicalPotential : simtk.unit.Quantity
+        excessChemicalPotential : openmm.unit.Quantity
             Excess chemical potential of the system that the simulation should be in equilibrium with, default is
             -6.09 kcal/mol. This should be the hydration free energy of water, and may need to be changed for specific
             simulation parameters.
-        standardVolume : simtk.unit.Quantity
+        standardVolume : openmm.unit.Quantity
             Standard volume of water - corresponds to the volume per water molecule in bulk. The default value is 30.345 A^3
         adamsShift : float
             Shift the B value from Bequil, if B isn't explicitly set. Default is 0.0
@@ -1218,7 +1218,7 @@ class NonequilibriumGCMCSphereSampler(GCMCSphereSampler):
             Number of pertubation steps over which to shift lambda between 0 and 1 (or vice versa).
         nPropStepsPerPert : int
             Number of propagation steps to carry out for
-        timeStep : simtk.unit.Quantity
+        timeStep : openmm.unit.Quantity
             Time step to use for non-equilibrium integration during the propagation steps
         lambdas : list
             Series of lambda values corresponding to the pathway over which the molecules are perturbed
@@ -1230,9 +1230,9 @@ class NonequilibriumGCMCSphereSampler(GCMCSphereSampler):
             List containing dictionaries describing the atoms to use as the centre of the GCMC region
             Must contain 'name' and 'resname' as keys, and optionally 'resid' (recommended) and 'chain'
             e.g. [{'name': 'C1', 'resname': 'LIG', 'resid': '123'}]
-        sphereRadius : simtk.unit.Quantity
+        sphereRadius : openmm.unit.Quantity
             Radius of the spherical GCMC region
-        sphereCentre : simtk.unit.Quantity
+        sphereCentre : openmm.unit.Quantity
             Coordinates around which the GCMC sphere is based
         log : str
             Name of the log file to write out
@@ -1294,7 +1294,7 @@ class NonequilibriumGCMCSphereSampler(GCMCSphereSampler):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         n : int
             Number of moves to execute
@@ -1532,25 +1532,25 @@ class GCMCSystemSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             System object to be used for the simulation
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system to be simulated
-        temperature : simtk.unit.Quantity
+        temperature : openmm.unit.Quantity
             Temperature of the simulation, must be in appropriate units
         adams : float
             Adams B value for the simulation (dimensionless). Default is None,
             if None, the B value is calculated from the box volume and chemical
             potential
-        excessChemicalPotential : simtk.unit.Quantity
+        excessChemicalPotential : openmm.unit.Quantity
             Excess chemical potential of the system that the simulation should be in equilibrium with, default is
             -6.09 kcal/mol. This should be the hydration free energy of water, and may need to be changed for specific
             simulation parameters.
-        standardVolume : simtk.unit.Quantity
+        standardVolume : openmm.unit.Quantity
             Standard volume of water - corresponds to the volume per water molecule in bulk. The default value is 30.345 A^3
         adamsShift : float
             Shift the B value from Bequil, if B isn't explicitly set. Default is 0.0
-        boxVectors : simtk.unit.Quantity
+        boxVectors : openmm.unit.Quantity
             Box vectors for the simulation cell
         ghostFile : str
             Name of a file to write out the residue IDs of ghost water molecules. This is
@@ -1595,7 +1595,7 @@ class GCMCSystemSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         ghostResids : list
             List of residue IDs corresponding to the ghost waters added
@@ -1635,7 +1635,7 @@ class GCMCSystemSampler(BaseGrandCanonicalMonteCarloSampler):
 
         Returns
         -------
-        new_positions : simtk.unit.Quantity
+        new_positions : openmm.unit.Quantity
             Positions following the 'insertion' of the ghost water
         insert_water : int
             Residue ID of the water to insert
@@ -1720,25 +1720,25 @@ class StandardGCMCSystemSampler(GCMCSystemSampler):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             System object to be used for the simulation
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system to be simulated
-        temperature : simtk.unit.Quantity
+        temperature : openmm.unit.Quantity
             Temperature of the simulation, must be in appropriate units
         adams : float
             Adams B value for the simulation (dimensionless). Default is None,
             if None, the B value is calculated from the box volume and chemical
             potential
-        excessChemicalPotential : simtk.unit.Quantity
+        excessChemicalPotential : openmm.unit.Quantity
             Excess chemical potential of the system that the simulation should be in equilibrium with, default is
             -6.09 kcal/mol. This should be the hydration free energy of water, and may need to be changed for specific
             simulation parameters.
-        standardVolume : simtk.unit.Quantity
+        standardVolume : openmm.unit.Quantity
             Standard volume of water - corresponds to the volume per water molecule in bulk. The default value is 30.345 A^3
         adamsShift : float
             Shift the B value from Bequil, if B isn't explicitly set. Default is 0.0
-        boxVectors : simtk.unit.Quantity
+        boxVectors : openmm.unit.Quantity
             Box vectors for the simulation cell
         ghostFile : str
             Name of a file to write out the residue IDs of ghost water molecules. This is
@@ -1768,7 +1768,7 @@ class StandardGCMCSystemSampler(GCMCSystemSampler):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         n : int
             Number of moves to execute
@@ -1874,24 +1874,24 @@ class NonequilibriumGCMCSystemSampler(GCMCSystemSampler):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             System object to be used for the simulation
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system to be simulated
-        temperature : simtk.unit.Quantity
+        temperature : openmm.unit.Quantity
             Temperature of the simulation, must be in appropriate units
-        integrator : simtk.openmm.CustomIntegrator
+        integrator : openmm.CustomIntegrator
             Integrator to use to propagate the dynamics of the system. Currently want to make sure that this
             is the customised Langevin integrator found in openmmtools which uses BAOAB (VRORV) splitting.
         adams : float
             Adams B value for the simulation (dimensionless). Default is None,
             if None, the B value is calculated from the box volume and chemical
             potential
-        excessChemicalPotential : simtk.unit.Quantity
+        excessChemicalPotential : openmm.unit.Quantity
             Excess chemical potential of the system that the simulation should be in equilibrium with, default is
             -6.09 kcal/mol. This should be the hydration free energy of water, and may need to be changed for specific
             simulation parameters.
-        standardVolume : simtk.unit.Quantity
+        standardVolume : openmm.unit.Quantity
             Standard volume of water - corresponds to the volume per water molecule in bulk. The default value is 30.345 A^3
         adamsShift : float
             Shift the B value from Bequil, if B isn't explicitly set. Default is 0.0
@@ -1899,11 +1899,11 @@ class NonequilibriumGCMCSystemSampler(GCMCSystemSampler):
             Number of pertubation steps over which to shift lambda between 0 and 1 (or vice versa).
         nPropStepsPerPert : int
             Number of propagation steps to carry out for
-        timeStep : simtk.unit.Quantity
+        timeStep : openmm.unit.Quantity
             Time step to use for non-equilibrium integration during the propagation steps
         lambdas : list
             Series of lambda values corresponding to the pathway over which the molecules are perturbed
-        boxVectors : simtk.unit.Quantity
+        boxVectors : openmm.unit.Quantity
             Box vectors for the simulation cell
         ghostFile : str
             Name of a file to write out the residue IDs of ghost water molecules. This is
@@ -1966,7 +1966,7 @@ class NonequilibriumGCMCSystemSampler(GCMCSystemSampler):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             Current context of the simulation
         n : int
             Number of moves to execute

--- a/grand/tests/test_potential.py
+++ b/grand/tests/test_potential.py
@@ -9,9 +9,9 @@ Marley Samways
 import os
 import unittest
 import numpy as np
-from simtk.unit import *
-from simtk.openmm.app import *
-from simtk.openmm import *
+from openmm.unit import *
+from openmm.app import *
+from openmm import *
 from grand import potential
 from grand import utils
 

--- a/grand/tests/test_samplers.py
+++ b/grand/tests/test_samplers.py
@@ -10,9 +10,9 @@ import os
 import unittest
 import numpy as np
 from copy import deepcopy
-from simtk.openmm.app import *
-from simtk.openmm import *
-from simtk.unit import *
+from openmm.app import *
+from openmm import *
+from openmm.unit import *
 from grand import samplers
 from grand import utils
 

--- a/grand/tests/test_utils.py
+++ b/grand/tests/test_utils.py
@@ -10,9 +10,9 @@ import os
 import unittest
 import numpy as np
 import mdtraj
-from simtk.unit import *
-from simtk.openmm import *
-from simtk.openmm.app import *
+from openmm.unit import *
+from openmm import *
+from openmm.app import *
 from grand import utils
 
 

--- a/grand/utils.py
+++ b/grand/utils.py
@@ -563,7 +563,7 @@ def wrap_waters(topology=None, trajectory=None, t=None, output=None):
     if t is None:
         t = mdtraj.load(trajectory, top=topology, discard_overlapping_frames=False)
 
-    n_frames = t.xyz.shape
+    n_frames = t.xyz.shape[0]
 
     # Fix all frames
     for f in range(n_frames):

--- a/grand/utils.py
+++ b/grand/utils.py
@@ -15,8 +15,8 @@ import os
 import numpy as np
 import mdtraj
 import parmed
-from simtk import unit
-from simtk.openmm import app
+from openmm import unit
+from openmm import app
 from copy import deepcopy
 from scipy.cluster import hierarchy
 import warnings
@@ -34,7 +34,7 @@ class PDBRestartReporter(object):
         ----------
         filename : str
             Name of the PDB file to write out
-        topology : simtk.openmm.app.Topology
+        topology : openmm.app.Topology
             Topology object for the system of interest
         """
         self.filename = filename
@@ -46,9 +46,9 @@ class PDBRestartReporter(object):
 
         Parameters
         ----------
-        simulation : simtk.openmm.app.Simulation
+        simulation : openmm.app.Simulation
             Simulation object being used
-        state : simtk.openmm.State
+        state : openmm.State
             Current State of the simulation
         """
         # Read the positions from the state
@@ -94,9 +94,9 @@ def add_ghosts(topology, positions, ff='tip3p', n=10, pdb='gcmc-extra-wats.pdb')
 
     Parameters
     ----------
-    topology : simtk.openmm.app.Topology
+    topology : openmm.app.Topology
         Topology of the initial system
-    positions : simtk.unit.Quantity
+    positions : openmm.unit.Quantity
         Atomic coordinates of the initial system
     ff : str
         Water forcefield to use. Currently only TIP3P is supported. 
@@ -108,9 +108,9 @@ def add_ghosts(topology, positions, ff='tip3p', n=10, pdb='gcmc-extra-wats.pdb')
 
     Returns
     -------
-    modeller.topology : simtk.openmm.app.Topology
+    modeller.topology : openmm.app.Topology
         Topology of the system after modification
-    modeller.positions : simtk.unit.Quantity
+    modeller.positions : openmm.unit.Quantity
         Atomic positions of the system after modification
     ghosts : list
         List of the residue numbers (counting from 0) of the ghost
@@ -180,9 +180,9 @@ def remove_ghosts(topology, positions, ghosts=None, pdb='gcmc-removed-ghosts.pdb
 
     Parameters
     ----------
-    topology : simtk.openmm.app.Topology
+    topology : openmm.app.Topology
         Topology of the initial system
-    positions : simtk.unit.Quantity
+    positions : openmm.unit.Quantity
         Atomic coordinates of the initial system
     ghosts : list
         List of residue IDs for the ghost waters to be deleted
@@ -192,9 +192,9 @@ def remove_ghosts(topology, positions, ghosts=None, pdb='gcmc-removed-ghosts.pdb
 
     Returns
     -------
-    modeller.topology : simtk.openmm.app.Topology
+    modeller.topology : openmm.app.Topology
         Topology of the system after modification
-    modeller.positions : simtk.unit.Quantity
+    modeller.positions : openmm.unit.Quantity
         Atomic positions of the system after modification
     """
     # Do nothing if no ghost waters are specified
@@ -780,7 +780,7 @@ def write_sphere_traj(radius, ref_atoms=None, topology=None, trajectory=None, t=
         Trajectory file, such as DCD
     t : mdtraj.Trajectory
         Trajectory object, if already loaded
-    sphere_centre : simtk.unit.Quantity
+    sphere_centre : openmm.unit.Quantity
         Coordinates around which the GCMC sphere is based
     output : str
         Name of the output PDB file
@@ -885,7 +885,7 @@ def cluster_waters(topology, trajectory, sphere_radius, ref_atoms=None, sphere_c
         Radius of the GCMC sphere in Angstroms
     ref_atoms : list
         List of reference atoms for the GCMC sphere (list of dictionaries)
-    sphere_centre : simtk.unit.Quantity
+    sphere_centre : openmm.unit.Quantity
         Coordinates around which the GCMC sphere is based
     cutoff : float
         Distance cutoff used in the clustering


### PR DESCRIPTION
OpenMM's add_solvent function can add a chain for the solvent with a two-letter name. That broke the logic for what chain letter should be used for the new ghost waters.